### PR TITLE
Add setuptools to requirements (Fix #78)

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,1 +1,2 @@
 biopython
+setuptools


### PR DESCRIPTION
This fixes the error reported in #78 by adding `setuptools` to `requirements.txt`.

After adding it, and installing it from there, the python scripts now work for me without throwing errors (only some warnings):

```bash
$ python kleborate-runner.py 
/home/shl/proj/24/50-klebsiella-hyper/.pixi/envs/default/lib/python3.12/site-packages/Bio/pairwise2.py:278: BiopythonDeprecationWarning: Bio.pairwise2 has been deprecated, and we intend to remove it in a future release of Biopython. As an alternative, please consider using Bio.Align.PairwiseAligner as a replacement, and contact the Biopython developers if you still need the Bio.pairwise2 module.
  warnings.warn(
usage: kleborate-runner.py -a ASSEMBLIES [ASSEMBLIES ...] [-r] [--kaptive_k] [--kaptive_o] [-k] [--all] [-o OUTFILE] [--kaptive_k_outfile KAPTIVE_K_OUTFILE] [--kaptive_o_outfile KAPTIVE_O_OUTFILE] [--min_identity MIN_IDENTITY] [--min_coverage MIN_COVERAGE] [--min_spurious_identity MIN_SPURIOUS_IDENTITY]
                           [--min_spurious_coverage MIN_SPURIOUS_COVERAGE] [--min_kaptive_confidence {None,Low,Good,High,Very_high,Perfect}] [--force_index] [-h] [--version]

Kleborate: a tool for characterising virulence and resistance in Klebsiella

Required arguments:
  -a ASSEMBLIES [ASSEMBLIES ...], --assemblies ASSEMBLIES [ASSEMBLIES ...]
                                        FASTA file(s) for assemblies

Screening options:
  -r, --resistance                      Turn on resistance genes screening (default: no resistance gene screening)
  --kaptive_k                           Turn on Kaptive screening of K loci (default: do not run Kaptive for K loci)
  --kaptive_o                           Turn on Kaptive screening of O loci (default: do not run Kaptive for O loci)
  -k, --kaptive                         Equivalent to --kaptive_k --kaptive_o
  --all                                 Equivalent to --resistance --kaptive

Output options:
  -o OUTFILE, --outfile OUTFILE         File for detailed output (default: Kleborate_results.txt)
  --kaptive_k_outfile KAPTIVE_K_OUTFILE
                                        File for full Kaptive K locus output (default: do not save Kaptive K locus results to separate file)
  --kaptive_o_outfile KAPTIVE_O_OUTFILE
                                        File for full Kaptive O locus output (default: do not save Kaptive O locus results to separate file)

Settings:
  --min_identity MIN_IDENTITY           Minimum alignment percent identity for main results (default: 90.0)
  --min_coverage MIN_COVERAGE           Minimum alignment percent coverage for main results (default: 80.0)
  --min_spurious_identity MIN_SPURIOUS_IDENTITY
                                        Minimum alignment percent identity for spurious results (default: 80.0)
  --min_spurious_coverage MIN_SPURIOUS_COVERAGE
                                        Minimum alignment percent coverage for spurious results (default: 40.0)
  --min_kaptive_confidence {None,Low,Good,High,Very_high,Perfect}
                                        Minimum Kaptive confidence to call K/O loci - confidence levels below this will be reported as unknown (default: Good)

Other:
  --force_index                         Rebuild the BLAST index at the start of execution (default: only build BLAST indices when they are missing)

Help:
  -h, --help                            Show this help message and exit
  --version                             Show program's version number and exit

If you use Kleborate, please cite the paper:
    Lam MMC, et al. A genomic surveillance framework and genotyping tool
    for Klebsiella pneumoniae and its related species complex. Nature
    Communications. 2021. doi:10.1038/s41467-021-24448-3.

If you turn on the Kaptive option for full K and O typing, please also cite Kaptive:
    Wyres KL, et al. Identification of Klebsiella capsule synthesis loci from
    whole genome data. Microbial Genomics. 2016. doi:10.1099/mgen.0.000102.

```

```bash
$ python setup.py
/home/shl/proj/24/50-klebsiella-hyper/kleborate/setup.py:89: SyntaxWarning: invalid escape sequence '\ '
  "| | / /| |   |  ____|  _ \ / __ \|  __ \   /\|__   __|  ____|\n" \
/home/shl/proj/24/50-klebsiella-hyper/kleborate/setup.py:90: SyntaxWarning: invalid escape sequence '\ '
  "| |/ / | |   | |__  | |_) | |  | | |__) | /  \  | |  | |__   \n" \
/home/shl/proj/24/50-klebsiella-hyper/kleborate/setup.py:91: SyntaxWarning: invalid escape sequence '\ '
  "|   <  | |   |  __| |  _ <| |  | |  _  / / /\ \ | |  |  __|  \n" \
/home/shl/proj/24/50-klebsiella-hyper/kleborate/setup.py:92: SyntaxWarning: invalid escape sequence '\ '
  "| |\ \ | |___| |____| |_) | |__| | | \ \/ ____ \| |  | |____ \n" \
/home/shl/proj/24/50-klebsiella-hyper/kleborate/setup.py:93: SyntaxWarning: invalid escape sequence '\_'
  "|_| \_\|_____|______|____/ \____/|_|  \_\/    \_\_|  |______|\n"
usage: setup.py [global_opts] cmd1 [cmd1_opts] [cmd2 [cmd2_opts] ...]
   or: setup.py --help [cmd1 cmd2 ...]
   or: setup.py --help-commands
   or: setup.py cmd --help

error: no commands supplied
```